### PR TITLE
helios: include packagegroup-storage-encryption-initramfs

### DIFF
--- a/init-helios-env
+++ b/init-helios-env
@@ -144,6 +144,8 @@ require `pwd`/../layers/meta-secure-env/templates/feature/storage-encryption/tem
 require `pwd`/../layers/intel-apollolake/templates/default/template.conf
 require `pwd`/../layers/meta-gateway/templates/default/template.conf
 
+ROOTFS_BOOTSTRAP_INSTALL += "packagegroup-storage-encryption-initramfs"
+
 CUBE_ESSENTIAL_EXTRA_INSTALL += "\
     packagegroup-uefi-secure-boot \
     packagegroup-mok-secure-boot \


### PR DESCRIPTION
In order to support rootfs encryption, this packagegroup is required to
include the necessary packages in initramfs.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>