### PR TITLE
wr-core: install perl-bignum on Fedora

### DIFF
--- a/scripts/host_package_install.sh
+++ b/scripts/host_package_install.sh
@@ -16,10 +16,10 @@ RH6_x86_64='glibc.i686 glibc-devel.i686 glibc-devel.x86_64 libgcc.i686 ncurses-l
 RH7_x86_64='glibc.i686 glibc-devel.i686 glibc-devel.x86_64 libgcc.i686 ncurses-libs.i686 perl-Text-ParseWords perl-podlators perl-autodie perl-Thread-Queue hostname texi2html diffstat subversion mesa-libGL mesa-libGLU SDL-devel texinfo gawk gcc gcc-c++ help2man chrpath git pygtk2 bzip2 wget tar patch xz make diffutils file screen qemu-img btrfs-progs kpartx expect dosfstools parted e2fsprogs'
 
 #Fedora 19+ i386
-F19_i686='perl-Text-ParseWords perl-podlators perl-autodie perl-Thread-Queue hostname texi2html diffstat subversion mesa-libGL mesa-libGLU SDL-devel texinfo gawk gcc gcc-c++ help2man chrpath git pygtk2 bzip2 wget tar patch xz make diffutils file screen qemu-img btrfs-progs kpartx expect dosfstools parted e2fsprogs'
+F19_i686='perl-Text-ParseWords perl-podlators perl-autodie perl-Thread-Queue hostname texi2html diffstat subversion mesa-libGL mesa-libGLU SDL-devel texinfo gawk gcc gcc-c++ help2man chrpath git pygtk2 bzip2 wget tar patch xz make diffutils file screen qemu-img btrfs-progs kpartx expect dosfstools parted e2fsprogs perl-bignum'
 
 #Fedora 19+ x86_64
-F19_x86_64='glibc.i686 glibc-devel.i686 glibc-devel.x86_64 libgcc.i686 ncurses-libs.i686 perl-Text-ParseWords perl-podlators perl-autodie perl-Thread-Queue hostname texi2html diffstat subversion mesa-libGL mesa-libGLU SDL-devel texinfo gawk gcc gcc-c++ help2man chrpath git pygtk2 bzip2 wget tar patch xz make diffutils file screen qemu-img btrfs-progs kpartx expect dosfstools parted e2fsprogs'
+F19_x86_64='glibc.i686 glibc-devel.i686 glibc-devel.x86_64 libgcc.i686 ncurses-libs.i686 perl-Text-ParseWords perl-podlators perl-autodie perl-Thread-Queue hostname texi2html diffstat subversion mesa-libGL mesa-libGLU SDL-devel texinfo gawk gcc gcc-c++ help2man chrpath git pygtk2 bzip2 wget tar patch xz make diffutils file screen qemu-img btrfs-progs kpartx expect dosfstools parted e2fsprogs perl-bignum'
 
 #Ubuntu 10.04 i386
 U1004_i686='texi2html chrpath diffstat subversion libgl1-mesa-dev libglu1-mesa-dev libsdl1.2-dev libncurses5-dev texinfo gawk gcc gcc-multilib help2man g++ git-core python-gtk2 bash diffutils xz-utils make file screen qemu-utils btrfs-tools kpartx expect dosfstools parted e2fsprogs'


### PR DESCRIPTION
This package is needed to build openssl, see the following
error on Fedora 25:

ERROR: The perl module 'bignum' was not found but this is required to
build openssl.  Please install this module (often packaged as
perl-bignum) and re-run bitbake.
ERROR: Function failed: do_configure (log file is located at
/buildarea1/ywei/wr-core/build-lanner-lec-2137/tmp/work/x86_64-linux/openssl-native/1.0.2d-r0/temp/log.do_configure.2043)
ERROR: Logfile of failure stored in:
/buildarea1/ywei/wr-core/build-lanner-lec-2137/tmp/work/x86_64-linux/openssl-native/1.0.2d-r0/temp/log.do_configure.2043
ERROR: Task 223
(virtual:native:/buildarea1/ywei/wr-core/layers/oe-core/meta/recipes-connectivity/openssl/openssl_1.0.2d.bb,
do_configure) failed with exit code '1'

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>