### PR TITLE
init scripts: clean up CUBE_ESSENTIAL_EXTRA_INSTALL

### DIFF
--- a/init-advantech-utx-3117-env
+++ b/init-advantech-utx-3117-env
@@ -143,12 +143,6 @@ require $OEROOT/../meta-gateway/templates/default/template.conf
 require $OEROOT/../meta-secure-env/templates/feature/tpm/template.conf
 require $OEROOT/../meta-secure-env/templates/feature/tpm2/template.conf
 
-CUBE_ESSENTIAL_EXTRA_INSTALL += "\
-    packagegroup-uefi-secure-boot \
-    packagegroup-mok-secure-boot \
-    packagegroup-tpm \
-"
-
 # Kernel overrides
 INHERIT += "blacklist"
 PNBLACKLIST[linux-windriver] = "Recipe not buildable without local kernel git"

--- a/init-intel-apollolake-env
+++ b/init-intel-apollolake-env
@@ -156,12 +156,6 @@ if [ -f $OEROOT/../../../default/template.conf ] ; then
 fi
 
 cat<<EOF>>conf/local.conf
-CUBE_ESSENTIAL_EXTRA_INSTALL += "\
-    packagegroup-uefi-secure-boot \
-    packagegroup-mok-secure-boot \
-    packagegroup-tpm2 \
-"
-
 # Kernel overrides
 INHERIT += "blacklist"
 PNBLACKLIST[linux-windriver] = "Recipe not buildable without local kernel git"

--- a/init-lanner-lec-2137-env
+++ b/init-lanner-lec-2137-env
@@ -142,12 +142,6 @@ require $OEROOT/../meta-secure-env/templates/feature/tpm2/template.conf
 require $OEROOT/../intel-apollolake/templates/default/template.conf
 require $OEROOT/../meta-gateway/templates/default/template.conf
 
-CUBE_ESSENTIAL_EXTRA_INSTALL += "\
-    packagegroup-uefi-secure-boot \
-    packagegroup-mok-secure-boot \
-    packagegroup-tpm2 \
-"
-
 # Kernel overrides
 INHERIT += "blacklist"
 PNBLACKLIST[linux-windriver] = "Recipe not buildable without local kernel git"


### PR DESCRIPTION
The infrastructure makes sure the essential-only packages are not
installed.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>