### PR TITLE
Clean up template requirements.

### DIFF
--- a/init-Dell-Caracalla-env
+++ b/init-Dell-Caracalla-env
@@ -135,13 +135,7 @@ require $OEROOT/../wr-base/templates/default/template.conf
 require $OEROOT/../wrlabs-integration/templates/default/template.conf
 require $OEROOT/../meta-gateway/templates/default/template.conf
 require $OEROOT/../meta-secure-env/templates/default/template.conf
-require $OEROOT/../meta-secure-env/templates/feature/tpm/template.conf
 require $OEROOT/../meta-secure-env/templates/feature/tpm2/template.conf
-
-CUBE_ESSENTIAL_EXTRA_INSTALL += "\
-    packagegroup-tpm2 \
-"
-
 
 # Kernel overrides
 INHERIT += "blacklist"

--- a/init-advantech-utx-3117-env
+++ b/init-advantech-utx-3117-env
@@ -136,11 +136,9 @@ require $OEROOT/../wr-kernel/templates/default/template.conf
 require $OEROOT/../wr-base/templates/default/template.conf
 require $OEROOT/../wrlabs-integration/templates/default/template.conf
 require $OEROOT/../meta-secure-env/templates/default/template.conf
-require $OEROOT/../meta-secure-env/templates/feature/uefi-secure-boot/template.conf
 require $OEROOT/../meta-secure-env/templates/feature/mok-secure-boot/template.conf
 require $OEROOT/../intel-apollolake/templates/default/template.conf
 require $OEROOT/../meta-gateway/templates/default/template.conf
-require $OEROOT/../meta-secure-env/templates/feature/tpm/template.conf
 require $OEROOT/../meta-secure-env/templates/feature/tpm2/template.conf
 
 # Kernel overrides

--- a/init-intel-apollolake-env
+++ b/init-intel-apollolake-env
@@ -144,9 +144,7 @@ require $OEROOT/../wr-kernel/templates/default/template.conf
 require $OEROOT/../wr-base/templates/default/template.conf
 require $OEROOT/../wrlabs-integration/templates/default/template.conf
 require $OEROOT/../meta-secure-env/templates/default/template.conf
-require $OEROOT/../meta-secure-env/templates/feature/uefi-secure-boot/template.conf
 require $OEROOT/../meta-secure-env/templates/feature/mok-secure-boot/template.conf
-require $OEROOT/../meta-secure-env/templates/feature/tpm/template.conf
 require $OEROOT/../meta-secure-env/templates/feature/tpm2/template.conf
 require $OEROOT/../intel-apollolake/templates/default/template.conf
 require $OEROOT/../meta-gateway/templates/default/template.conf

--- a/init-lanner-lec-2137-env
+++ b/init-lanner-lec-2137-env
@@ -135,9 +135,7 @@ require $OEROOT/../wr-kernel/templates/default/template.conf
 require $OEROOT/../wr-base/templates/default/template.conf
 require $OEROOT/../wrlabs-integration/templates/default/template.conf
 require $OEROOT/../meta-secure-env/templates/default/template.conf
-require $OEROOT/../meta-secure-env/templates/feature/uefi-secure-boot/template.conf
 require $OEROOT/../meta-secure-env/templates/feature/mok-secure-boot/template.conf
-require $OEROOT/../meta-secure-env/templates/feature/tpm/template.conf
 require $OEROOT/../meta-secure-env/templates/feature/tpm2/template.conf
 require $OEROOT/../intel-apollolake/templates/default/template.conf
 require $OEROOT/../meta-gateway/templates/default/template.conf


### PR DESCRIPTION
tpm and uefi-secure-boot are automatically required by tpm2 and
mok-secure-boot implicitly.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>