### PR TITLE
host_package_install.sh: adding pexpect

### DIFF
--- a/scripts/host_package_install.sh
+++ b/scripts/host_package_install.sh
@@ -1,52 +1,52 @@
 #!/bin/sh
 
 #RedHat 5.x i386
-RH5_i686='binutils220 texi2html diffstat subversion mesa-libGL mesa-libGLU SDL-devel texinfo gawk gcc gcc-c++ help2man chrpath git pygtk2 bzip2 wget tar patch xz make diffutils file screen qemu-img btrfs-progs kpartx expect dosfstools parted e2fsprogs'
+RH5_i686='binutils220 texi2html diffstat subversion mesa-libGL mesa-libGLU SDL-devel texinfo gawk gcc gcc-c++ help2man chrpath git pygtk2 bzip2 wget tar patch xz make diffutils file screen qemu-img btrfs-progs kpartx expect dosfstools parted e2fsprogs pexpect'
 
 #RedHat 5.x x86_64
-RH5_x86_64='glibc.i686 glibc-devel.i386 glibc-devel.x86_64 libgcc.i386 ncurses.i386 binutils220 texi2html diffstat subversion mesa-libGL mesa-libGLU SDL-devel texinfo gawk gcc gcc-c++ help2man chrpath git pygtk2 bzip2 wget tar patch xz make diffutils file screen qemu-img btrfs-progs kpartx expect dosfstools parted e2fsprogs'
+RH5_x86_64='glibc.i686 glibc-devel.i386 glibc-devel.x86_64 libgcc.i386 ncurses.i386 binutils220 texi2html diffstat subversion mesa-libGL mesa-libGLU SDL-devel texinfo gawk gcc gcc-c++ help2man chrpath git pygtk2 bzip2 wget tar patch xz make diffutils file screen qemu-img btrfs-progs kpartx expect dosfstools parted e2fsprogs pexpect'
 
 #RedHat 6.x and Fedora 15 16 17 18 i386
-RH6_i686='texi2html diffstat subversion mesa-libGL mesa-libGLU SDL-devel texinfo gawk gcc gcc-c++ help2man chrpath git pygtk2 bzip2 wget tar patch xz make diffutils file screen qemu-img btrfs-progs kpartx expect dosfstools parted e2fsprogs'
+RH6_i686='texi2html diffstat subversion mesa-libGL mesa-libGLU SDL-devel texinfo gawk gcc gcc-c++ help2man chrpath git pygtk2 bzip2 wget tar patch xz make diffutils file screen qemu-img btrfs-progs kpartx expect dosfstools parted e2fsprogs pexpect'
 
 #RedHat 6.x and Fedora 15 16 17 18 x86_64
-RH6_x86_64='glibc.i686 glibc-devel.i686 glibc-devel.x86_64 libgcc.i686 ncurses-libs.i686 texi2html diffstat subversion mesa-libGL mesa-libGLU SDL-devel texinfo gawk gcc gcc-c++ help2man chrpath git pygtk2 bzip2 wget tar patch xz make diffutils file screen qemu-img btrfs-progs kpartx expect dosfstools parted e2fsprogs'
+RH6_x86_64='glibc.i686 glibc-devel.i686 glibc-devel.x86_64 libgcc.i686 ncurses-libs.i686 texi2html diffstat subversion mesa-libGL mesa-libGLU SDL-devel texinfo gawk gcc gcc-c++ help2man chrpath git pygtk2 bzip2 wget tar patch xz make diffutils file screen qemu-img btrfs-progs kpartx expect dosfstools parted e2fsprogs pexpect'
 
 #RedHat 7.x x86_64
-RH7_x86_64='glibc.i686 glibc-devel.i686 glibc-devel.x86_64 libgcc.i686 ncurses-libs.i686 perl-Text-ParseWords perl-podlators perl-autodie perl-Thread-Queue hostname texi2html diffstat subversion mesa-libGL mesa-libGLU SDL-devel texinfo gawk gcc gcc-c++ help2man chrpath git pygtk2 bzip2 wget tar patch xz make diffutils file screen qemu-img btrfs-progs kpartx expect dosfstools parted e2fsprogs'
+RH7_x86_64='glibc.i686 glibc-devel.i686 glibc-devel.x86_64 libgcc.i686 ncurses-libs.i686 perl-Text-ParseWords perl-podlators perl-autodie perl-Thread-Queue hostname texi2html diffstat subversion mesa-libGL mesa-libGLU SDL-devel texinfo gawk gcc gcc-c++ help2man chrpath git pygtk2 bzip2 wget tar patch xz make diffutils file screen qemu-img btrfs-progs kpartx expect dosfstools parted e2fsprogs pexpect'
 
 #Fedora 19+ i386
-F19_i686='perl-Text-ParseWords perl-podlators perl-autodie perl-Thread-Queue hostname texi2html diffstat subversion mesa-libGL mesa-libGLU SDL-devel texinfo gawk gcc gcc-c++ help2man chrpath git pygtk2 bzip2 wget tar patch xz make diffutils file screen qemu-img btrfs-progs kpartx expect dosfstools parted e2fsprogs perl-bignum'
+F19_i686='perl-Text-ParseWords perl-podlators perl-autodie perl-Thread-Queue hostname texi2html diffstat subversion mesa-libGL mesa-libGLU SDL-devel texinfo gawk gcc gcc-c++ help2man chrpath git pygtk2 bzip2 wget tar patch xz make diffutils file screen qemu-img btrfs-progs kpartx expect dosfstools parted e2fsprogs perl-bignum pexpect'
 
 #Fedora 19+ x86_64
-F19_x86_64='glibc.i686 glibc-devel.i686 glibc-devel.x86_64 libgcc.i686 ncurses-libs.i686 perl-Text-ParseWords perl-podlators perl-autodie perl-Thread-Queue hostname texi2html diffstat subversion mesa-libGL mesa-libGLU SDL-devel texinfo gawk gcc gcc-c++ help2man chrpath git pygtk2 bzip2 wget tar patch xz make diffutils file screen qemu-img btrfs-progs kpartx expect dosfstools parted e2fsprogs perl-bignum'
+F19_x86_64='glibc.i686 glibc-devel.i686 glibc-devel.x86_64 libgcc.i686 ncurses-libs.i686 perl-Text-ParseWords perl-podlators perl-autodie perl-Thread-Queue hostname texi2html diffstat subversion mesa-libGL mesa-libGLU SDL-devel texinfo gawk gcc gcc-c++ help2man chrpath git pygtk2 bzip2 wget tar patch xz make diffutils file screen qemu-img btrfs-progs kpartx expect dosfstools parted e2fsprogs perl-bignum pexpect'
 
 #Ubuntu 10.04 i386
-U1004_i686='texi2html chrpath diffstat subversion libgl1-mesa-dev libglu1-mesa-dev libsdl1.2-dev libncurses5-dev texinfo gawk gcc gcc-multilib help2man g++ git-core python-gtk2 bash diffutils xz-utils make file screen qemu-utils btrfs-tools kpartx expect dosfstools parted e2fsprogs'
+U1004_i686='texi2html chrpath diffstat subversion libgl1-mesa-dev libglu1-mesa-dev libsdl1.2-dev libncurses5-dev texinfo gawk gcc gcc-multilib help2man g++ git-core python-gtk2 bash diffutils xz-utils make file screen qemu-utils btrfs-tools kpartx expect dosfstools parted e2fsprogs python-pexpect'
 
 #Ubuntu 10.04 x86_64
-U1004_x86_64='libc6-i386 libc6-dev-i386 lib32ncurses5 texi2html chrpath diffstat subversion libgl1-mesa-dev libglu1-mesa-dev libsdl1.2-dev libncurses5-dev texinfo gawk gcc gcc-multilib help2man g++ git-core python-gtk2 bash diffutils xz-utils make file screen qemu-utils btrfs-tools kpartx expect dosfstools parted e2fsprogs'
+U1004_x86_64='libc6-i386 libc6-dev-i386 lib32ncurses5 texi2html chrpath diffstat subversion libgl1-mesa-dev libglu1-mesa-dev libsdl1.2-dev libncurses5-dev texinfo gawk gcc gcc-multilib help2man g++ git-core python-gtk2 bash diffutils xz-utils make file screen qemu-utils btrfs-tools kpartx expect dosfstools parted e2fsprogs python-pexpect'
 
 #Ubuntu 12.04 i386
-U1204_i686='texi2html chrpath diffstat subversion libgl1-mesa-dev libglu1-mesa-dev libsdl1.2-dev libncurses5-dev texinfo gawk gcc gcc-multilib help2man g++ git-core python-gtk2 bash diffutils xz-utils make file screen qemu-utils btrfs-tools kpartx expect dosfstools parted e2fsprogs'
+U1204_i686='texi2html chrpath diffstat subversion libgl1-mesa-dev libglu1-mesa-dev libsdl1.2-dev libncurses5-dev texinfo gawk gcc gcc-multilib help2man g++ git-core python-gtk2 bash diffutils xz-utils make file screen qemu-utils btrfs-tools kpartx expect dosfstools parted e2fsprogs python-pexpect'
 
 #Ubuntu 12.04 x86_64
-U1204_x86_64='texi2html chrpath diffstat subversion libgl1-mesa-dev libglu1-mesa-dev libsdl1.2-dev libncurses5-dev texinfo gawk gcc gcc-multilib help2man g++ git-core python-gtk2 bash diffutils xz-utils make file screen qemu-utils btrfs-tools kpartx expect dosfstools parted e2fsprogs'
+U1204_x86_64='texi2html chrpath diffstat subversion libgl1-mesa-dev libglu1-mesa-dev libsdl1.2-dev libncurses5-dev texinfo gawk gcc gcc-multilib help2man g++ git-core python-gtk2 bash diffutils xz-utils make file screen qemu-utils btrfs-tools kpartx expect dosfstools parted e2fsprogs python-pexpect'
 
 #OpenSuSE 12.1 i386
-OS121_i686='chrpath diffstat subversion Mesa Mesa-devel make libSDL-devel texinfo gawk gcc gcc-c++ help2man patch python-curses python-xml libsqlite3-0 glibc-locale git python-gtk diffutils xz file screen qemu-utils btrfs-tools kpartx expect dosfstools parted e2fsprogs'
+OS121_i686='chrpath diffstat subversion Mesa Mesa-devel make libSDL-devel texinfo gawk gcc gcc-c++ help2man patch python-curses python-xml libsqlite3-0 glibc-locale git python-gtk diffutils xz file screen qemu-utils btrfs-tools kpartx expect dosfstools parted e2fsprogs python-pexpect'
 
 #OpenSuSE 12.1 x86_64
-OS121_x86_64='gcc-32bit libncurses5-32bit chrpath diffstat subversion Mesa Mesa-devel make libSDL-devel texinfo gawk gcc gcc-c++ help2man patch python-curses python-xml libsqlite3-0 glibc-locale git python-gtk diffutils xz file screen qemu-utils btrfs-tools kpartx expect dosfstools parted e2fsprogs'
+OS121_x86_64='gcc-32bit libncurses5-32bit chrpath diffstat subversion Mesa Mesa-devel make libSDL-devel texinfo gawk gcc gcc-c++ help2man patch python-curses python-xml libsqlite3-0 glibc-locale git python-gtk diffutils xz file screen qemu-utils btrfs-tools kpartx expect dosfstools parted e2fsprogs python-pexpect'
 
 #SLED 11 SP2 i386 (requires SLE 11 SP2 SDK)
-SLED112_i686='make texinfo gawk gcc gcc-c++ patch diffstat subversion chrpath Mesa-devel SDL-devel python-curses glibc-locale tcl git python-gtk diffutils xz file screen qemu-utils btrfs-tools kpartx expect dosfstools parted e2fsprogs'
+SLED112_i686='make texinfo gawk gcc gcc-c++ patch diffstat subversion chrpath Mesa-devel SDL-devel python-curses glibc-locale tcl git python-gtk diffutils xz file screen qemu-utils btrfs-tools kpartx expect dosfstools parted e2fsprogs python-pexpect'
 
 #SLED 11 SP2 x86_64 (requires SLE 11 SP2 SDK)
-SLED112_x86_64='gcc43-32bit libncurses5-32bit make texinfo gawk gcc gcc-c++ patch diffstat subversion chrpath Mesa-devel SDL-devel python-curses glibc-locale tcl git python-gtk diffutils xz file screen qemu-utils btrfs-tools kpartx expect dosfstools parted e2fsprogs'
+SLED112_x86_64='gcc43-32bit libncurses5-32bit make texinfo gawk gcc gcc-c++ patch diffstat subversion chrpath Mesa-devel SDL-devel python-curses glibc-locale tcl git python-gtk diffutils xz file screen qemu-utils btrfs-tools kpartx expect dosfstools parted e2fsprogs python-pexpect'
 
 #SLED 12 x86_64 (requires SLE 12 SDK)
-SLED12_x86_64='gcc-32bit libncurses5-32bit make texinfo gawk gcc gcc-c++ patch diffstat subversion chrpath Mesa-devel libSDL-devel python-curses glibc-locale tcl git python-gtk diffutils xz file screen qemu-utils btrfs-tools kpartx expect dosfstools parted e2fsprogs'
+SLED12_x86_64='gcc-32bit libncurses5-32bit make texinfo gawk gcc gcc-c++ patch diffstat subversion chrpath Mesa-devel libSDL-devel python-curses glibc-locale tcl git python-gtk diffutils xz file screen qemu-utils btrfs-tools kpartx expect dosfstools parted e2fsprogs python-pexpect'
 
 arch=`uname -m`
 distro=""


### PR DESCRIPTION
rpm signing needs to install python pexpect on build host, so adding it
in host_package_install.sh.

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>