### PR TITLE
init-intel-x86-env-secure: don't define initramfs image

### DIFF
--- a/init-intel-x86-env-secure
+++ b/init-intel-x86-env-secure
@@ -86,8 +86,6 @@ IMAGE_FSTYPES += "live"
 MULTILIBS = "multilib:lib32"
 DEFAULTTUNE_virtclass-multilib-lib32 = "x86"
 
-INITRAMFS_IMAGE = "secure-core-image-initramfs"
-
 require ../layers/wrlabs-integration/templates/feature/efi-secure-boot/template.conf
 require ../layers/wrlabs-integration/templates/feature/ima/template.conf
 require ../layers/wrlabs-integration/templates/feature/encrypted-storage/template.conf


### PR DESCRIPTION
secure-core-image-initramfs is used by SecureCore. Pulsar uses its
dedicated initramfs image type.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>