### PR TITLE
init-intel-x86-secure-env: include feature/luks

### DIFF
--- a/init-intel-x86-secure-env
+++ b/init-intel-x86-secure-env
@@ -88,7 +88,7 @@ DEFAULTTUNE_virtclass-multilib-lib32 = "x86"
 
 require ../layers/wrlabs-integration/templates/feature/efi-secure-boot/template.conf
 require ../layers/wrlabs-integration/templates/feature/ima/template.conf
-require ../layers/wrlabs-integration/templates/feature/encrypted-storage/template.conf
+require ../layers/wrlabs-integration/templates/feature/luks/template.conf
 require ../layers/wrlabs-integration/templates/feature/tpm/template.conf
 require ../layers/wrlabs-integration/templates/feature/tpm2/template.conf
 '


### PR DESCRIPTION
feature/encrypted-storage now is renamed to feature/luks.

Note: this PR depends on https://github.com/WindRiver-OpenSourceLabs/wrlabs-integration/pull/33

Signed-off-by: Jia Zhang <lans.zhang2008@gmail.com>