### PR TITLE
init-intel-x86-secure-env: inherit sign_rpm_ext

### DIFF
--- a/init-intel-x86-secure-env
+++ b/init-intel-x86-secure-env
@@ -91,6 +91,8 @@ require ../layers/wrlabs-integration/templates/feature/ima/template.conf
 require ../layers/wrlabs-integration/templates/feature/luks/template.conf
 require ../layers/wrlabs-integration/templates/feature/tpm/template.conf
 require ../layers/wrlabs-integration/templates/feature/tpm2/template.conf
+
+INHERIT += "sign_rpm_ext"
 '
 
 source $OEROOT/../../scripts/common_init


### PR DESCRIPTION
This definition should be placed in local.conf rather than layer.conf.

Note: this commit depends on the latest meta-secure-core.

Signed-off-by: Jia Zhang <lans.zhang2008@gmail.com>