### PR TITLE
init-intel-x86-secure-env: inherit sign_rpm by default

### DIFF
--- a/init-intel-x86-secure-env
+++ b/init-intel-x86-secure-env
@@ -92,7 +92,7 @@ require ../layers/wrlabs-integration/templates/feature/luks/template.conf
 require ../layers/wrlabs-integration/templates/feature/tpm/template.conf
 require ../layers/wrlabs-integration/templates/feature/tpm2/template.conf
 
-INHERIT += "sign_rpm_ext"
+INHERIT += "sign_rpm"
 '
 
 source $OEROOT/../../scripts/common_init


### PR DESCRIPTION
sign_rpm_ext with RPM file signing support should be configured with
feature/ima. RPM package signing is always configired as long as
meta-secure-core is included. Therefore, it is reasonable to inhert
sign_rpm by default, instead of inherit sign_rpm_ext.

Note: this commit is associated with https://github.com/WindRiver-OpenSourceLabs/wrlabs-integration/pull/34

Signed-off-by: Jia Zhang <lans.zhang2008@gmail.com>