### PR TITLE
Enable container authentication for IntelCubeDesktop-live.sh

### DIFF
--- a/install_templates/IntelCubeDesktop/IntelCubeDesktop-live.sh
+++ b/install_templates/IntelCubeDesktop/IntelCubeDesktop-live.sh
@@ -14,3 +14,16 @@ NETWORK_DEVICE="eth+ wl+ en+"
 
 #HDINSTALL_CONTAINERS="${ARTIFACTS_DIR}/cube-dom0-intel-corei7-64.tar.bz2"
 INSTALL_ROOTFS="${ARTIFACTS_DIR}/cube-essential-intel-corei7-64.tar.bz2"
+
+export LOCAL_CUSTOM_HDD_POST_FUNCS="my_local_post_func"
+
+my_local_post_func()
+{
+        #copy the HAL id&passwd from dom0 to cube-srver/cube-gw/cube-desktop
+        CNS="cube-server cube-gw cube-desktop"
+        for c in ${CNS}; do
+                if [ -d ${TMPMNT}/opt/container/$c/rootfs ]; then
+                        cat ${TMPMNT}/opt/container/dom0/rootfs/var/lib/cube-cmd-server/auth.db > ${TMPMNT}/opt/container/$c/rootfs/etc/cube-cmd.auth
+                fi
+        done
+}


### PR DESCRIPTION
Add the missing overc-installer hook to give the containers
authorization to issue cube commands.

This was missing and comes from IntelNUCServer-live.sh.  Without
it, the user is requested for an id and password if they use
cube-console or cube-cmd.

Signed-off-by: Rob Woolley <rob.woolley@windriver.com>