### PR TITLE
init-*-env scripts: delete superfluous second test of BBSERVER

### DIFF
--- a/init-intel-x86-env
+++ b/init-intel-x86-env
@@ -28,10 +28,6 @@ if [ -n "$BBSERVER" ]; then
    unset BBSERVER
 fi
 
-if [ -n "$BBSERVER" ]; then
-   unset BBSERVER
-fi
-
 # Figure out the "TOP" relative to TOP/layers/oe-core
 THIS_SCRIPT=`dirname $OEROOT`
 THIS_SCRIPT=`dirname $THIS_SCRIPT`

--- a/init-intel-x86-secure-env
+++ b/init-intel-x86-secure-env
@@ -28,10 +28,6 @@ if [ -n "$BBSERVER" ]; then
    unset BBSERVER
 fi
 
-if [ -n "$BBSERVER" ]; then
-   unset BBSERVER
-fi
-
 # Figure out the "TOP" relative to TOP/layers/oe-core
 THIS_SCRIPT=`dirname $OEROOT`
 THIS_SCRIPT=`dirname $THIS_SCRIPT`

--- a/init-raspberrypi-env
+++ b/init-raspberrypi-env
@@ -28,10 +28,6 @@ if [ -n "$BBSERVER" ]; then
    unset BBSERVER
 fi
 
-if [ -n "$BBSERVER" ]; then
-   unset BBSERVER
-fi
-
 # Figure out the "TOP" relative to TOP/layers/oe-core
 THIS_SCRIPT=`dirname $OEROOT`
 THIS_SCRIPT=$THIS_SCRIPT/init-raspberrypi-env

--- a/todo/init-fsl-ls10xx-env
+++ b/todo/init-fsl-ls10xx-env
@@ -28,10 +28,6 @@ if [ -n "$BBSERVER" ]; then
    unset BBSERVER
 fi
 
-if [ -n "$BBSERVER" ]; then
-   unset BBSERVER
-fi
-
 # Figure out the "TOP" relative to TOP/layers/oe-core
 THIS_SCRIPT=`dirname $OEROOT`
 THIS_SCRIPT=$THIS_SCRIPT/init-fsl-ls10xx-env

--- a/todo/init-xilinx-zynq-env
+++ b/todo/init-xilinx-zynq-env
@@ -28,10 +28,6 @@ if [ -n "$BBSERVER" ]; then
    unset BBSERVER
 fi
 
-if [ -n "$BBSERVER" ]; then
-   unset BBSERVER
-fi
-
 # Figure out the "TOP" relative to TOP/layers/oe-core
 THIS_SCRIPT=`dirname $OEROOT`
 THIS_SCRIPT=$THIS_SCRIPT/init-xilinx-zynq-env


### PR DESCRIPTION
Weirdly, all of these init-*-env scripts test BBSERVER twice
exactly the same way.

Signed-off-by: Robert P. J. Day <rpjday@crashcourse.ca>